### PR TITLE
Not possible to use $.ajax(...).abort()

### DIFF
--- a/deferred.coffee
+++ b/deferred.coffee
@@ -144,9 +144,14 @@ installInto = (fw) ->
     # Rinse and repeat for errors. We can now use `request.fail(callback)`.
     options.error = createWrapper options.error, def.reject
 
-    ajax(options)
+    xhr = ajax(options)
 
-    def.promise()
+    promise = def.promise()
+    promise.abort = ->
+      xhr.abort()
+      options.error xhr, 'abort', 'abort'
+
+    promise
   # Let's also alias the `.when()` method, for good measure.
   fw.when = _when
 


### PR DESCRIPTION
Using with zepto (`Deferred.installInto(Zepto);`); it is not possible to cancel an in flight ajax request with `$.ajax(...).abort()` like you can in jquery because an ordinary promise is returned from $.ajax()

The attached commit fails the test cases because it returns a promise with an extra attribute (`.abort()`) -- you very well may want to handle it a different way but this was the starting point I was thinking of.
