### PR TITLE
always()/when() functions invoked in different order to jquery

### DIFF
--- a/deferred.coffee
+++ b/deferred.coffee
@@ -52,7 +52,6 @@ Deferred = ->
   state = PENDING
   doneCallbacks = []
   failCallbacks = []
-  alwaysCallbacks = []
   closingArguments = {}
   # Calling `.promise()` gives you an object that you pass around your code indiscriminately. 
   # Any code can add callbacks to a `promise`, but none can alter the state of the `deferred` itself. 
@@ -73,7 +72,9 @@ Deferred = ->
     # or failure callbacks using `.fail(callback)`,
     candidate.fail = storeCallbacks((-> state is REJECTED), failCallbacks)
     # or register a callback to always fire when the deferred is either resolved or rejected - using `.always(callback)`
-    candidate.always = storeCallbacks((-> state isnt PENDING), alwaysCallbacks)
+    candidate.always = ->
+      execute [candidate.done, candidate.fail], arguments 
+      return candidate
 
     # It also makes sense to set up a piper to which can filter the success or failure arguments through the given filter methods. 
     # Quite useful if you want to transform the results of a promise or log them in some way. 
@@ -103,7 +104,7 @@ Deferred = ->
       if state is PENDING
         state = finalState
         closingArguments = arguments
-        execute [callbacks, alwaysCallbacks], closingArguments, context
+        execute callbacks, closingArguments, context
       return this
   # Now we can set up `.resolve([args])` method to close the deferred and call the `done` callbacks,
   @resolve = close RESOLVED, doneCallbacks


### PR DESCRIPTION
Jquery's implementation of `.always()` is just a shorthand for adding to both the done and fail queues:

```
...
            promise = {
                state: function() {
                    return state;
                },
                always: function() {
                    deferred.done( arguments ).fail( arguments );
                    return this;
                },
...
```

simply-deferred maintains a 3rd queue of `alwaysCallbacks`. These are invoked after the `done` and `fail` callbacks. This causes functions to be invoked in a different order to jquery.

Attached patch copies the jquery behaviour. Apologies no new test case -- coffeescript + async/deferred code hurts my head at this time of night. The linked jsfiddles are regular JS tests that demonstrate the bug (and test `.when()` too) -- attached patch fixes it).

 JQuery: http://jsfiddle.net/6WSWS/2/
 Simply Deferred: http://jsfiddle.net/hHp9C/1/
