### PR TITLE
.when() doesn't pass on .reject() arguments to .fail() handlers

### DIFF
--- a/deferred.coffee
+++ b/deferred.coffee
@@ -122,7 +122,7 @@ _when = ->
   defs = flatten arguments
   finish = after defs.length, trigger.resolve
   def.done(finish) for def in defs
-  def.fail(-> trigger.reject()) for def in defs
+  def.fail(trigger.reject) for def in defs
   trigger.promise()
 
 # Since the core team of [Zepto](http://zeptojs.com/) (and maybe other jQuery compatible libraries) don't seem to like the idea of Deferreds / Promises too much, 


### PR DESCRIPTION
Fixes bug that `.when()` passes on the `.resolve()` arguments to `.done()` handlers, but doesn't pass on `.reject()` arguments to `.fail()` handlers

Demonstrated in the following jsfiddles:
JQuery: http://jsfiddle.net/LKkWU/1/
simply-deferred :http://jsfiddle.net/cFKBH/1/
