### PR TITLE
Fixed an incompatible API of `resolveWith` & `rejectWith`.

### DIFF
--- a/deferred.coffee
+++ b/deferred.coffee
@@ -122,8 +122,8 @@ Deferred = ->
   # and `.reject([args])` to fail it and call the `fail` callbacks.
   @reject = close REJECTED, failCallbacks
   # We can also set up `.resolveWith(context, [args])` and `.rejectWith(context, [args])` to allow setting an execution scope for the callbacks.
-  @resolveWith = (context, args...) -> close(RESOLVED, doneCallbacks, context)(args...)
-  @rejectWith = (context, args...) -> close(REJECTED, failCallbacks, context)(args...)
+  @resolveWith = (context, args) -> close(RESOLVED, doneCallbacks, context).apply this, args
+  @rejectWith = (context, args) -> close(REJECTED, failCallbacks, context).apply this, args
 
   return this
 

--- a/deferred.js
+++ b/deferred.js
@@ -155,15 +155,11 @@
     };
     this.resolve = close(RESOLVED, doneCallbacks);
     this.reject = close(REJECTED, failCallbacks);
-    this.resolveWith = function() {
-      var args, context;
-      context = arguments[0], args = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
-      return close(RESOLVED, doneCallbacks, context).apply(null, args);
+    this.resolveWith = function(context, args) {
+      return close(RESOLVED, doneCallbacks, context).apply(this, args);
     };
-    this.rejectWith = function() {
-      var args, context;
-      context = arguments[0], args = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
-      return close(REJECTED, failCallbacks, context).apply(null, args);
+    this.rejectWith = function(context, args) {
+      return close(REJECTED, failCallbacks, context).apply(this, args);
     };
     return this;
   };


### PR DESCRIPTION
I'm not sure these are bugs, but I've found an incompatibility of `resolveWith` & `rejectWith` with jQuery.Deferred.
- resolveWith & rejectWith take `args` as an Array (See http://api.jquery.com/deferred.resolveWith/)
- resolveWith & rejectWith return a deferred object, not a Window object.

Try the following expressions on both of jQuery.Deferred & simply-deferred 2.2.0:
#### 1. The return value

``` javascript
//   jQuery.Deferred: Returns a deferred object.
//   simply-deferred: Returns a Window object.
$.Deferred().resolveWith();
```
#### 2. The arguments

``` javascript
//   jQuery.Deferred: Prints ['a', 'b'].
//   simply-deferred: Prints [['a', 'b']].
var deferred = $.Deferred();
deferred.promise().done(function() {
    console.log(arguments);
});
deferred.resolveWith(deferred, ['a', 'b']);
```
