### PR TITLE
AMD-friendly and auto-installInto(Zepto)

### DIFF
--- a/deferred.coffee
+++ b/deferred.coffee
@@ -187,6 +187,14 @@ if (typeof exports isnt 'undefined')
   exports.Deferred = -> new Deferred()
   exports.when = _when
   exports.installInto = installInto
+else if typeof define is 'function' && define.amd
+  define ()->
+    if Zepto
+      installInto(Zepto)
+    else
+      Deferred
+else if Zepto
+  installInto(Zepto)
 else
 # and the browser by setting the functions on `window`.
   this.Deferred = -> new Deferred();


### PR DESCRIPTION
Plays nice with AMD loaders. Installs itself into Zepto if Zepto is detected.
