### PR TITLE
Implement jQuery compatible `.pipe()`

### DIFF
--- a/deferred.coffee
+++ b/deferred.coffee
@@ -137,6 +137,10 @@ Deferred = ->
 # Let's set up a `.when([deferreds])` method to do that. It should be able to take any number or deferreds as arguments (or an array of them).
 _when = ->
   defs = flatten arguments
+  if defs.length == 1
+    # small optimization: pass a single deferred object along
+    return if isPromise defs[0] then defs[0] else (new Deferred()).resolve(defs[0]).promise()
+
   trigger = new Deferred()
   return trigger.resolve().promise() if not defs.length
 

--- a/deferred.js
+++ b/deferred.js
@@ -161,6 +161,13 @@
   _when = function() {
     var def, defs, finish, resolutionArgs, trigger, _i, _len;
     defs = flatten(arguments);
+    if (defs.length === 1) {
+      if (isPromise(defs[0])) {
+        return defs[0];
+      } else {
+        return (new Deferred()).resolve(defs[0]).promise();
+      }
+    }
     trigger = new Deferred();
     if (!defs.length) {
       return trigger.resolve().promise();

--- a/deferred_test.coffee
+++ b/deferred_test.coffee
@@ -259,6 +259,7 @@ describe 'deferred', ->
       it 'should pass on resolve arguments as is when used with a single deferred', (done) ->
         d1 = new deferred.Deferred()
         after_all = deferred.when(d1)
+        assert.equal d1, after_all
         after_all.done (arg1) -> done() if arg1 is 42
         d1.resolve(42)
 

--- a/deferred_test.js
+++ b/deferred_test.js
@@ -351,6 +351,7 @@
           var after_all, d1;
           d1 = new deferred.Deferred();
           after_all = deferred.when(d1);
+          assert.equal(d1, after_all);
           after_all.done(function(arg1) {
             if (arg1 === 42) {
               return done();


### PR DESCRIPTION
jQuery let's the filters passed into `.pipe()` optionally return a promise-like object. The state of the promise object (resolved / rejected) is replicated into the master deferred returned by `.pipe()`.

The previous implementation did not properly replicate the state into the master deferred. For example, a `.done()` filter could return a deferred that had been rejected, but the master deferred would still end up being resolved. The test case in 6ee9772 does a better job illustrating this concept.

b19540a fixes the typo from my last pull request and adds a test case for the optimization: https://github.com/rraval/simply-deferred/commit/d1f6a41fc051ccf6d57127c1582f2d5b4355ab2c#deferred-coffee-P20
